### PR TITLE
feat: separate tags in tags input

### DIFF
--- a/app/NoteOptions.tsx
+++ b/app/NoteOptions.tsx
@@ -10,7 +10,7 @@ import { LANGUAGES, RELAYS } from "./constants";
 import TextInput from "./TextInput";
 
 export default function NoteOptions({ text, onSetSyntaxOption }: any) {
-  const [syntax, setSyntax] = useState("");
+  const [syntax, setSyntax] = useState("markdown");
   const [postLoading, setPostLoading] = useState(false);
   const relayUrlInput = useRef<HTMLSelectElement>(null);
   const router = useRouter();
@@ -24,7 +24,7 @@ export default function NoteOptions({ text, onSetSyntaxOption }: any) {
     const relay = await NostrService.connect(relayUrlInput.current?.value || "wss://nostr-pub.wellorder.net");
     const privateKey = NostrService.genPrivateKey();
     const publicKey = NostrService.genPublicKey(privateKey);
-    const event = NostrService.createEvent(publicKey, text, syntax);
+    const event = NostrService.createEvent(publicKey, text, syntax, tagsList);
     const eventId = await NostrService.post(relay, privateKey, event);
     console.log(eventId);
     router.push("/note/" + eventId);
@@ -34,15 +34,17 @@ export default function NoteOptions({ text, onSetSyntaxOption }: any) {
     onSetSyntaxOption(e.target.value);
     setSyntax(e.target.value);
   }
+    console.log(syntax)
 
   const validateTagsInputKeyDown = (event: any) => {
-    if (event.key === "Enter") {
+    const TAG_KEYS = ["Enter", ",", " "];
+    if (TAG_KEYS.some((key) => key === event.key)) {
       event.preventDefault();
       if (tagInputValue) {
         setTagsList(Array.from(new Set([...tagsList, tagInputValue])));
         setTagInputValue("");
-      }
-    } 
+      } 
+    }
   }
 
   return (
@@ -58,7 +60,7 @@ export default function NoteOptions({ text, onSetSyntaxOption }: any) {
           <Select
             label="Syntax"
             options={LANGUAGES}
-            onChange={(e: any) => handleSelect(e)}
+            onChange={handleSelect}
             defaultValue="markdown"
           />
           {/* <Select */}

--- a/app/NoteOptions.tsx
+++ b/app/NoteOptions.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import "websocket-polyfill";
-import { useRef, useState } from "react";
+import { ChangeEvent, useRef, useState } from "react";
 import { useRouter } from "next/navigation";
 import { NostrService } from "./utils/NostrService";
 import Button from "./Button";
@@ -14,6 +14,8 @@ export default function NoteOptions({ text, onSetSyntaxOption }: any) {
   const [postLoading, setPostLoading] = useState(false);
   const relayUrlInput = useRef<HTMLSelectElement>(null);
   const router = useRouter();
+  const [tagInputValue, setTagInputValue] = useState<string>("");
+  const [tagsList, setTagsList] = useState<string[]>([]);
 
   const post = async (e: any) => {
     e.preventDefault();
@@ -31,6 +33,16 @@ export default function NoteOptions({ text, onSetSyntaxOption }: any) {
   function handleSelect(e: any) {
     onSetSyntaxOption(e.target.value);
     setSyntax(e.target.value);
+  }
+
+  const validateTagsInputKeyDown = (event: any) => {
+    if (event.key === "Enter") {
+      event.preventDefault();
+      if (tagInputValue) {
+        setTagsList(Array.from(new Set([...tagsList, tagInputValue])));
+        setTagInputValue("");
+      }
+    } 
   }
 
   return (
@@ -56,9 +68,15 @@ export default function NoteOptions({ text, onSetSyntaxOption }: any) {
           <TextInput
             label="Tags"
             placeholder="Enter tags..."
+            onKeyDown={validateTagsInputKeyDown}
+            value={tagInputValue}
+            onChange={(e) => setTagInputValue(e.target.value)}
+            tagsList={tagsList}
+            setTagsList={setTagsList}
           />
           <Select
             label="Relay"
+            // FIXME: can't pass ref into react functional components
             ref={relayUrlInput}
             options={RELAYS}
           />

--- a/app/TextInput.tsx
+++ b/app/TextInput.tsx
@@ -57,6 +57,7 @@ const TextInput = ({ label, error, tagsList, setTagsList, placeholder = "", valu
                                       flex items-center gap-1">
                 {tag}
                 <Button
+                  className="w-auto"
                   icon= { <IoMdCloseCircleOutline /> }
                   size="sm"
                   color="transparent"

--- a/app/TextInput.tsx
+++ b/app/TextInput.tsx
@@ -1,11 +1,17 @@
 import { DetailedHTMLProps, InputHTMLAttributes, useId } from "react";
+import { IoMdCloseCircleOutline } from "react-icons/io"
+import Button from "./Button";
 
 interface TextInputProps extends DetailedHTMLProps<InputHTMLAttributes<HTMLInputElement>, HTMLInputElement> {
   label: string;
   error?: string;
+  tagsList?: string[];
+  // TODO: Figure out what type this should be
+  setTagsList?: any;
+  value?: string;
 }
 
-const TextInput = ({ label, error, placeholder = "", value = "", ...props }: TextInputProps) => {
+const TextInput = ({ label, error, tagsList, setTagsList, placeholder = "", value = "", ...props }: TextInputProps) => {
   const id = useId();
 
   return (
@@ -34,13 +40,40 @@ const TextInput = ({ label, error, placeholder = "", value = "", ...props }: Tex
                             ${value || placeholder ? "top-2" : "top-5"}
                           `}
           htmlFor={id}>{label}</label>
-        <input
-          type="text"
-          id={id}
-          className="px-3 py-2 w-full focus:border-0 bg-transparent border-0 outline-0 focus:ring-0 mt-5 text-neutral-800 dark:text-zinc-200"
-          placeholder={placeholder}
-          {...props}
-        />
+        <div className="mt-6">
+          {tagsList && tagsList.length > 0 ? <ul className="flex flex-wrap gap-2 px-3 pt-4">
+            {tagsList.map((tag) => (
+              <li key={tag} className="text-xs
+                                      bg-zinc-200
+                                      text-neutral-600
+                                      hover:text-neutral-800
+                                      dark:bg-neutral-600
+                                      dark:text-zinc-300
+                                      hover:dark:text-zinc-200
+                                      border 
+                                      border-neutral-500
+                                      hover:border-blue-500
+                                      rounded-md px-2 py-1
+                                      flex items-center gap-1">
+                {tag}
+                <Button
+                  icon= { <IoMdCloseCircleOutline /> }
+                  size="sm"
+                  color="transparent"
+                  onClick={() => setTagsList(tagsList.filter((tagInList) => tagInList !== tag))}
+                />
+              </li>
+            ))}
+          </ul> : null}
+          <input
+            type="text"
+            id={id}
+            className="w-full py-2 focus:border-0 bg-transparent border-0 outline-0 focus:ring-0 text-neutral-800 dark:text-zinc-200"
+            placeholder={placeholder}
+            value={value}
+            {...props}
+          />
+        </div>
       </div>
       {error && <p className="text-red-400 pl-3 text-sm mt-1">{error}</p>}
     </div>

--- a/app/note/[eventid]/page.tsx
+++ b/app/note/[eventid]/page.tsx
@@ -22,7 +22,11 @@ export default async function NotePage({ params }: any) {
         <p className="text-slate-300">pubkey: {note?.pubkey}</p>
         <p className="text-slate-300">content: {note?.content}</p>
         <p className="text-slate-300">kind: {note?.kind}</p>
-        <p className="text-slate-300">tags: {note?.tags}</p>
+        <ul className="text-slate-300">tags:
+          {note?.tags.map(([title, content]: string[]) => (
+            <li key={title} className="pl-4">{`${title}: ${content}`}</li>
+          ))}
+        </ul>
         <p className="text-slate-300">sig: {note?.sig}</p>
         <p className="text-slate-300">created_at: {note?.created_at}</p>
       </div>

--- a/app/utils/NostrService.ts
+++ b/app/utils/NostrService.ts
@@ -53,7 +53,8 @@ export namespace NostrService {
   export function createEvent(
     publicKey: string,
     content: string,
-    syntax: string
+    syntax: string,
+    tagsList: string[]
   ) {
     const event: Event = {
       kind: 2222,
@@ -62,7 +63,7 @@ export namespace NostrService {
       tags: [
         ["syntax", syntax],
         ["client", "notebin"],
-        ["tags", "TODO"],
+        ["tags", tagsList.join(",")],
         ["ln_address", "TODO"],
       ],
       content: content,


### PR DESCRIPTION
- tags can't be repeated more than once
![image](https://user-images.githubusercontent.com/69465962/212485782-d3d484ef-08af-48a3-baef-7621b191c6f4.png)
- pressing "Enter" while focusing on tags input append the value to the tags list and clear the input.
  should we do it on other keys? like comma or space ? 

**edit:** I did comma and space, feel free to change it from here 
https://github.com/nodetec/NoteBin/blob/6f6ac5abf78facb2d88f52d508ca06cdde4112af/app/NoteOptions.tsx#L40
but keep a special character for joining the array while sending the tags and then splitting the string into array.