### PR TITLE
feat: error flow for if publish note fails #42

### DIFF
--- a/app/HeaderContent.tsx
+++ b/app/HeaderContent.tsx
@@ -3,7 +3,6 @@ import Link from "next/link";
 import { useContext, useEffect, useState } from "react";
 import { BsLightningChargeFill } from "react-icons/bs";
 import { TbNote } from "react-icons/tb";
-import { useNostr } from "nostr-react";
 import Popup from "./Popup";
 
 import Button from "./Button";
@@ -63,11 +62,11 @@ export default function Header() {
     setIsLightningConnected(true);
   };
 
-  const shortenHash = (hash: string) => {
+  /* const shortenHash = (hash: string) => {
     if (hash) {
       return hash.substring(0, 4) + "..." + hash.substring(hash.length - 4);
     }
-  };
+  }; */
 
   return (
     <div>

--- a/app/NoteArea.tsx
+++ b/app/NoteArea.tsx
@@ -3,7 +3,7 @@ import { useContext, useState } from "react";
 import { useNostr } from "nostr-react";
 import Button from "./Button";
 import { NostrService } from "./utils/NostrService";
-/* import { EventContext } from "./context/event-provider"; */
+import { EventContext } from "./context/event-provider";
 import { KeysContext } from "./context/keys-provider.jsx";
 import { TipContext } from "./context/tip-provider.jsx";
 import { useRouter } from "next/navigation";
@@ -13,22 +13,25 @@ const NoteArea = () => {
   // @ts-ignore
   const { keys } = useContext(KeysContext);
   // @ts-ignore
-  /* const { setEvent } = useContext(EventContext); */
+  const { setEvent } = useContext(EventContext);
   // @ts-ignore
   const { tipInfo } = useContext(TipContext);
   const { publish } = useNostr();
-  /* const { connectedRelays } = useNostr(); */
+  const { connectedRelays } = useNostr();
 
   const router = useRouter();
   const [filetype, setFiletype] = useState("markdown");
   const [text, setText] = useState("");
   const [tagInputValue, setTagInputValue] = useState<string>("");
   const [tagsList, setTagsList] = useState<string[]>([]);
-  const [{postSending, postError}, setPost] = useState({postSending: false, postError: ""});
+  const [{ postSending, postError }, setPost] = useState({
+    postSending: false,
+    postError: "",
+  });
 
   const post = async (e: any) => {
     e.preventDefault();
-    setPost({postSending: true, postError: ""});
+    setPost({ postSending: true, postError: "" });
 
     const publicKey = keys.publicKey;
 
@@ -43,8 +46,8 @@ const NoteArea = () => {
 
     try {
       event = await NostrService.addEventData(event);
-    } catch(err: any) {
-      setPost({postSending: false, postError: err.message});
+    } catch (err: any) {
+      setPost({ postSending: false, postError: err.message });
       return;
     }
     console.log("gonna publish");
@@ -60,6 +63,7 @@ const NoteArea = () => {
       ]);
       sub.on("event", (event: Event) => {
         console.log("we got the event we wanted:", event);
+        setEvent(event);
         router.push("/note/" + eventId);
       });
       sub.on("eose", () => {
@@ -73,7 +77,7 @@ const NoteArea = () => {
     for await (const pub of pubs) {
       pub.on("ok", () => {
         console.log("OUR EVENT WAS ACCEPTED");
-        setPost({postSending: false, postError: ""});
+        setPost({ postSending: false, postError: "" });
       });
 
       await pub.on("seen", async () => {
@@ -81,7 +85,7 @@ const NoteArea = () => {
       });
 
       pub.on("failed", (reason: any) => {
-        setPost({postSending: false, postError: reason});
+        setPost({ postSending: false, postError: reason });
         console.log("OUR EVENT HAS FAILED");
       });
     }


### PR DESCRIPTION
This is all I got with the failures, I didn't figure out why in some weird situations it fails, but at least now the button will indicate if the user cancels from the extension, and on `pub.on("failed", ...)` it'll indicate the error message and log the error to the console, also I noticed the post will fail the first time you logged in, but after refresh and reconnect it'll work with no issues, at least for me.

This is the different scenarios I'm getting:
- if I'm not logged in, or I'm logged in the first time without refreshing the page, and tried to post
![image](https://user-images.githubusercontent.com/69465962/212917615-c37d5332-a097-40d7-99f5-3ade3c40dfd5.png)
- if canceled from the extension:
![image](https://user-images.githubusercontent.com/69465962/212918022-8e256c82-04fe-4e41-b7e9-b4a132391264.png)
